### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @paketo-community/ruby-maintainers
+* @paketo-buildpacks/ruby-maintainers


### PR DESCRIPTION
The change reflects migration into paketo-buildpacks. This probably needs to be done on the implementation repos as well.