### PR TITLE
Add rake as optional to all order groups.

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -54,6 +54,11 @@ api = "0.6"
     version = "0.4.1"
 
   [[order.group]]
+    id = "paketo-buildpacks/rake"
+    optional = true
+    version = "0.2.1"
+
+  [[order.group]]
     id = "paketo-buildpacks/puma"
     version = "0.2.1"
 
@@ -110,6 +115,11 @@ api = "0.6"
     id = "paketo-buildpacks/rails-assets"
     optional = true
     version = "0.4.1"
+
+  [[order.group]]
+    id = "paketo-buildpacks/rake"
+    optional = true
+    version = "0.2.1"
 
   [[order.group]]
     id = "paketo-buildpacks/thin"
@@ -170,6 +180,11 @@ api = "0.6"
     version = "0.4.1"
 
   [[order.group]]
+    id = "paketo-buildpacks/rake"
+    optional = true
+    version = "0.2.1"
+
+  [[order.group]]
     id = "paketo-buildpacks/unicorn"
     version = "0.2.1"
 
@@ -228,6 +243,11 @@ api = "0.6"
     version = "0.4.1"
 
   [[order.group]]
+    id = "paketo-buildpacks/rake"
+    optional = true
+    version = "0.2.1"
+
+  [[order.group]]
     id = "paketo-buildpacks/passenger"
     version = "0.4.0"
 
@@ -284,6 +304,11 @@ api = "0.6"
     id = "paketo-buildpacks/rails-assets"
     optional = true
     version = "0.4.1"
+
+  [[order.group]]
+    id = "paketo-buildpacks/rake"
+    optional = true
+    version = "0.2.1"
 
   [[order.group]]
     id = "paketo-buildpacks/rackup"


### PR DESCRIPTION
## Summary
<!-- A short explanation of the proposed change -->

This PR adds `rake` to all order groups, except the order group it is already present and required in.

This will close https://github.com/paketo-buildpacks/rake/issues/42 - see that issue for additional context.

I would like thoughts/feedback from the @paketo-buildpacks/ruby-maintainers as to how to best test this (or if we are happy not testing it). I can think of two ways:

1. Integration test by adding an optional `rake` command to one (or all) of the modified order groups. I don't like this because it significantly increases the complexity of the integration tests - especially if we retrospectively apply the logic to all optional buildpacks like Procfile or CA-Certificates
2. Create a new unit test that parses the `buildpack.toml` file and validates that the `rake` buildpack is present in all order groups, and optional in all-but-one. I don't like this approach because the test will be fairly hard to read and it adds minimal value.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
