### PR TITLE
Replace references to deprecated ioutil package.

### DIFF
--- a/integration/passenger_test.go
+++ b/integration/passenger_test.go
@@ -2,7 +2,6 @@ package integration_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -83,7 +82,7 @@ func testPassenger(t *testing.T, context spec.G, it spec.S) {
 
 		context("using optional utility buildpacks", func() {
 			it.Before(func() {
-				Expect(ioutil.WriteFile(filepath.Join(source, "Procfile"), []byte("web: bundle exec passenger start --port ${PORT}"), 0644)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(source, "Procfile"), []byte("web: bundle exec passenger start --port ${PORT}"), 0644)).To(Succeed())
 			})
 
 			it("builds a working image that complies with utility buildpack functions", func() {

--- a/integration/puma_test.go
+++ b/integration/puma_test.go
@@ -2,7 +2,6 @@ package integration_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -82,7 +81,7 @@ func testPuma(t *testing.T, context spec.G, it spec.S) {
 
 		context("using optional utility buildpacks", func() {
 			it.Before(func() {
-				Expect(ioutil.WriteFile(filepath.Join(source, "Procfile"), []byte("web: bundle exec puma -b tcp://0.0.0.0:${PORT}"), 0644)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(source, "Procfile"), []byte("web: bundle exec puma -b tcp://0.0.0.0:${PORT}"), 0644)).To(Succeed())
 			})
 
 			it("builds a working image that complies with utility buildpack functions", func() {

--- a/integration/rackup_test.go
+++ b/integration/rackup_test.go
@@ -2,7 +2,6 @@ package integration_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -83,7 +82,7 @@ func testRackup(t *testing.T, context spec.G, it spec.S) {
 
 		context("using optional utility buildpacks", func() {
 			it.Before(func() {
-				Expect(ioutil.WriteFile(filepath.Join(source, "Procfile"), []byte("web: bundle exec rackup -o 0.0.0.0 -p ${PORT}"), 0644)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(source, "Procfile"), []byte("web: bundle exec rackup -o 0.0.0.0 -p ${PORT}"), 0644)).To(Succeed())
 			})
 
 			it("builds a working image that complies with utility buildpack functions", func() {

--- a/integration/rake_test.go
+++ b/integration/rake_test.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -126,7 +126,7 @@ func testRake(t *testing.T, context spec.G, it spec.S) {
 				var err error
 				source, err = occam.Source(filepath.Join("testdata", "rake"))
 				Expect(err).NotTo(HaveOccurred())
-				Expect(ioutil.WriteFile(filepath.Join(source, "Procfile"), []byte("web: bundle exec rake proc"), 0644)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(source, "Procfile"), []byte("web: bundle exec rake proc"), 0644)).To(Succeed())
 			})
 
 			it("builds a working image that complies with utility buildpack functions", func() {
@@ -181,7 +181,7 @@ func testRake(t *testing.T, context spec.G, it spec.S) {
 				source, err = occam.Source(filepath.Join("testdata", "rake_ca_cert"))
 				Expect(err).NotTo(HaveOccurred())
 
-				caCert, err := ioutil.ReadFile(fmt.Sprintf("%s/certs/ca.pem", source))
+				caCert, err := os.ReadFile(fmt.Sprintf("%s/certs/ca.pem", source))
 				Expect(err).ToNot(HaveOccurred())
 
 				caCertPool := x509.NewCertPool()
@@ -245,7 +245,7 @@ func testRake(t *testing.T, context spec.G, it spec.S) {
 
 				Expect(response.StatusCode).To(Equal(http.StatusOK))
 
-				content, err := ioutil.ReadAll(response.Body)
+				content, err := io.ReadAll(response.Body)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(content)).To(ContainSubstring("Hello world, Authenticated User!"))
 			})

--- a/integration/thin_test.go
+++ b/integration/thin_test.go
@@ -2,7 +2,6 @@ package integration_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -83,7 +82,7 @@ func testThin(t *testing.T, context spec.G, it spec.S) {
 
 		context("using optional utility buildpacks", func() {
 			it.Before(func() {
-				Expect(ioutil.WriteFile(filepath.Join(source, "Procfile"), []byte("web: bundle exec thin -a 0.0.0.0 -p ${PORT} start"), 0644)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(source, "Procfile"), []byte("web: bundle exec thin -a 0.0.0.0 -p ${PORT} start"), 0644)).To(Succeed())
 			})
 
 			it("builds a working image that complies with utility buildpack functions", func() {

--- a/integration/unicorn_test.go
+++ b/integration/unicorn_test.go
@@ -2,7 +2,6 @@ package integration_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -86,7 +85,7 @@ func testUnicorn(t *testing.T, context spec.G, it spec.S) {
 
 		context("using optional utility buildpacks", func() {
 			it.Before(func() {
-				Expect(ioutil.WriteFile(filepath.Join(source, "Procfile"), []byte("web: bundle exec unicorn -l 0.0.0.0:${PORT}"), 0644)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(source, "Procfile"), []byte("web: bundle exec unicorn -l 0.0.0.0:${PORT}"), 0644)).To(Succeed())
 			})
 
 			it("builds a working image that complies with utility buildpack functions", func() {


### PR DESCRIPTION
This PR removes all references to the deprecated `ioutil` package and replaces them with their official replacements. See https://pkg.go.dev/io/ioutil for details on these replacements.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
