### PR TITLE
Bump mri buildpack to 0.8.0

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -23,7 +23,7 @@ api = "0.6"
 
   [[order.group]]
     id = "paketo-buildpacks/mri"
-    version = "0.7.0"
+    version = "0.8.0"
 
   [[order.group]]
     id = "paketo-buildpacks/bundler"
@@ -81,7 +81,7 @@ api = "0.6"
 
   [[order.group]]
     id = "paketo-buildpacks/mri"
-    version = "0.7.0"
+    version = "0.8.0"
 
   [[order.group]]
     id = "paketo-buildpacks/bundler"
@@ -139,7 +139,7 @@ api = "0.6"
 
   [[order.group]]
     id = "paketo-buildpacks/mri"
-    version = "0.7.0"
+    version = "0.8.0"
 
   [[order.group]]
     id = "paketo-buildpacks/bundler"
@@ -197,7 +197,7 @@ api = "0.6"
 
   [[order.group]]
     id = "paketo-buildpacks/mri"
-    version = "0.7.0"
+    version = "0.8.0"
 
   [[order.group]]
     id = "paketo-buildpacks/bundler"
@@ -255,7 +255,7 @@ api = "0.6"
 
   [[order.group]]
     id = "paketo-buildpacks/mri"
-    version = "0.7.0"
+    version = "0.8.0"
 
   [[order.group]]
     id = "paketo-buildpacks/bundler"
@@ -313,7 +313,7 @@ api = "0.6"
 
   [[order.group]]
     id = "paketo-buildpacks/mri"
-    version = "0.7.0"
+    version = "0.8.0"
 
   [[order.group]]
     id = "paketo-buildpacks/bundler"

--- a/package.toml
+++ b/package.toml
@@ -12,7 +12,7 @@
   uri = "urn:cnb:registry:paketo-buildpacks/image-labels@4.1.1"
 
 [[dependencies]]
-  uri = "urn:cnb:registry:paketo-buildpacks/mri@0.7.0"
+  uri = "urn:cnb:registry:paketo-buildpacks/mri@0.8.0"
 
 [[dependencies]]
   uri = "urn:cnb:registry:paketo-buildpacks/node-engine@0.12.3"


### PR DESCRIPTION
## Summary

Bumping MRI manually (to get a bugfix in the MRI dependency) while we figure out why the automation didn't work.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
