### PR TITLE
Allows tests to be run against stacks with differing build/run UIDs

### DIFF
--- a/integration/testdata/rails/config/puma.rb
+++ b/integration/testdata/rails/config/puma.rb
@@ -17,7 +17,7 @@ port        ENV.fetch("PORT") { 3000 }
 environment ENV.fetch("RAILS_ENV") { "development" }
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+pidfile ENV.fetch("PIDFILE") { "/tmp/puma.pid" }
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This change encapsulates what we should be encouraging users to do with their applications that write files to disk. Specifically, we should be telling users to write to locations on disk that are group-writable. In this case, we were writing to `/workspace/tmp/pids/server.pid`. This directory is not guaranteed to exist or be group-writable at runtime. Instead, we should write to `/tmp` as this is much more likely to have these group-writable permissions set.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
