### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -5,7 +5,7 @@ api = "0.6"
   homepage = "https://github.com/paketo-buildpacks/ruby"
   id = "paketo-buildpacks/ruby"
   keywords = ["ruby"]
-  name = "Paketo Ruby Buildpack"
+  name = "Paketo Buildpack for Ruby"
 
   [[buildpack.licenses]]
     type = "Apache-2.0"


### PR DESCRIPTION
Renames 'Paketo Ruby Buildpack' to 'Paketo Buildpack for Ruby'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
