### PR TITLE
Bump ca-certificates to 3.8.3

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   [[order.group]]
     id = "paketo-buildpacks/ca-certificates"
     optional = true
-    version = "3.8.2"
+    version = "3.8.3"
 
   [[order.group]]
     id = "paketo-buildpacks/mri"
@@ -77,7 +77,7 @@ api = "0.7"
   [[order.group]]
     id = "paketo-buildpacks/ca-certificates"
     optional = true
-    version = "3.8.2"
+    version = "3.8.3"
 
   [[order.group]]
     id = "paketo-buildpacks/mri"
@@ -135,7 +135,7 @@ api = "0.7"
   [[order.group]]
     id = "paketo-buildpacks/ca-certificates"
     optional = true
-    version = "3.8.2"
+    version = "3.8.3"
 
   [[order.group]]
     id = "paketo-buildpacks/mri"
@@ -193,7 +193,7 @@ api = "0.7"
   [[order.group]]
     id = "paketo-buildpacks/ca-certificates"
     optional = true
-    version = "3.8.2"
+    version = "3.8.3"
 
   [[order.group]]
     id = "paketo-buildpacks/mri"
@@ -251,7 +251,7 @@ api = "0.7"
   [[order.group]]
     id = "paketo-buildpacks/ca-certificates"
     optional = true
-    version = "3.8.2"
+    version = "3.8.3"
 
   [[order.group]]
     id = "paketo-buildpacks/mri"
@@ -309,7 +309,7 @@ api = "0.7"
   [[order.group]]
     id = "paketo-buildpacks/ca-certificates"
     optional = true
-    version = "3.8.2"
+    version = "3.8.3"
 
   [[order.group]]
     id = "paketo-buildpacks/mri"

--- a/package.toml
+++ b/package.toml
@@ -51,4 +51,4 @@
   uri = "urn:cnb:registry:paketo-buildpacks/environment-variables@4.7.0"
 
 [[dependencies]]
-  uri = "urn:cnb:registry:paketo-buildpacks/ca-certificates@3.8.2"
+  uri = "urn:cnb:registry:paketo-buildpacks/ca-certificates@3.8.3"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Bump ca-certificates to
[`3.8.3`](https://github.com/paketo-buildpacks/ca-certificates/releases/tag/v3.8.3).
This is needed in order the ruby buildpack to adopt the fix for
https://github.com/paketo-buildpacks/ca-certificates/issues/235
<!-- A short explanation of the proposed change -->

## Use Cases
See https://github.com/paketo-buildpacks/ca-certificates/issues/235
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
